### PR TITLE
Create android-user-certificates-trust.yaml

### DIFF
--- a/file/android/android-user-certificates-trust.yaml
+++ b/file/android/android-user-certificates-trust.yaml
@@ -17,4 +17,4 @@ file:
       - type: regex
         part: body
         regex:
-          - '<certificates\s+src\s*=\s*"user"\s*/>'
+          - '<certificates[^>]*\bsrc\s*=\s*"user"[^>]*/?>'

--- a/file/android/android-user-certificates-trust.yaml
+++ b/file/android/android-user-certificates-trust.yaml
@@ -8,11 +8,12 @@ info:
     The application is configured to trust user-added certificates, which may allow an attacker to perform MITM attacks.
   reference:
     - https://developer.android.com/training/articles/security-config#TrustingUserCerts
-   tags: file,android 
+  tags: file,android
 
 file:
   - extensions:
       - xml
+
     matchers:
       - type: regex
         part: body

--- a/file/android/android-user-certificates-trust.yaml
+++ b/file/android/android-user-certificates-trust.yaml
@@ -8,6 +8,7 @@ info:
     The application is configured to trust user-added certificates, which may allow an attacker to perform MITM attacks.
   reference:
     - https://developer.android.com/training/articles/security-config#TrustingUserCerts
+   tags: file,android 
 
 file:
   - extensions:

--- a/file/android/android-user-certificates-trust.yaml
+++ b/file/android/android-user-certificates-trust.yaml
@@ -1,0 +1,19 @@
+id: android-user-certificates-trust
+
+info:
+  name: Android Trusts User Certificates
+  author: Th3l0newolf
+  severity: medium
+  description: |
+    The application is configured to trust user-added certificates, which may allow an attacker to perform MITM attacks.
+  reference:
+    - https://developer.android.com/training/articles/security-config#TrustingUserCerts
+
+file:
+  - extensions:
+      - xml
+    matchers:
+      - type: regex
+        part: body
+        regex:
+          - '<certificates\s+src\s*=\s*"user"\s*/>'


### PR DESCRIPTION
The android  application is configured to trust user-added certificates by including <certificates src="user"/> in its network security configuration. This setting allows the app to accept certificates installed by the user, which can be exploited by an attacker to perform Man-in-the-Middle (MITM) attacks. An adversary can install a malicious root certificate and intercept encrypted traffic, potentially exposing sensitive user data.

### Template / PR Information

<!-- Explains the information and/or motivation for update or/ creating this templates -->
<!-- Please include any reference to your template if available -->
- References: CVE-2019-17626

### Template Validation

I've validated this template locally?
- [ ] YES



#### Additional Details (leave it blank if not applicable)
![PoC](https://github.com/user-attachments/assets/ee5b5249-046f-467d-a437-8f2342357172)




### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)