### PR TITLE
Create jamf-enroll-check added

### DIFF
--- a/http/exposed-panels/jamf-enroll-check.yaml
+++ b/http/exposed-panels/jamf-enroll-check.yaml
@@ -1,0 +1,27 @@
+id: jamf-enroll-check
+
+info:
+  name: Jamf /enroll/ Exposure Check
+  author: Th3l0newolf
+  severity: Medium
+  description: Detects if the /enroll/ endpoint is accessible on Jamf environments with basic auth being used and allows users to manually enroll their Mac, iPhone, or iPad into the organization’s Jamf environment
+  tags: jamf,exposure,mdm,enroll
+  metadata:
+    verified: true
+    shodan-query: 'ttitle:"Jamf Pro" http.html:"/enroll/"'
+    vendor: jamf
+    product: jamf
+    cvss-metrics: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:N'
+    cwe-id: 'CWE-307'  # Improper Restriction of Excessive Authentication Attempts
+
+requests:
+  - method: GET
+    path:
+      - "{{BaseURL}}/enroll/"
+
+    matchers:
+      - type: status
+        status:
+          - 200
+          - 403
+          - 401


### PR DESCRIPTION
### Template / PR Information

Detects if the /enroll/ endpoint is accessible on Jamf environments with basic auth being used and allows users to manually enroll their Mac, iPhone, or iPad into the organization’s Jamf environment. In case of basic auth is being used it is vulnerable to brute force attempts. 

- References: https://learn.jamf.com/en-US/bundle/jamf-pro-security-overview/page/Vulnerability_Assessments_Jamf_Pro.html

### Template Validation

I've validated this template locally?
- [ ] YES

![Jamf-enroll-check](https://github.com/user-attachments/assets/310a1613-bad6-48fa-8ee4-4d1cb9bdcb0c)



#### Additional Details (leave it blank if not applicable)

### Additional References:

- [Nuclei Template Creation Guideline](https://nuclei.projectdiscovery.io/templating-guide/)
- [Nuclei Template Matcher Guideline](https://github.com/projectdiscovery/nuclei-templates/wiki/Unique-Template-Matchers)
- [Nuclei Template Contribution Guideline](https://github.com/projectdiscovery/nuclei-templates/blob/master/CONTRIBUTING.md)
- [PD-Community Discord server](https://discord.gg/projectdiscovery)